### PR TITLE
Add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Andrew Margarit Portfolio
+
+This repository contains a small personal website showcasing Andrew Margarit's work as a dental hygienist and educational designer.
+
+## Portfolio Site
+
+The main site is [`index.html`](index.html) with accompanying CSS and JavaScript. It introduces Andrew, highlights his services, work experience, and qualifications, and includes a portfolio of projects. To view it locally, open `index.html` in your web browser:
+
+```bash
+# From the repository root
+open index.html       # macOS
+xdg-open index.html   # Linux
+start index.html      # Windows
+```
+
+You can also use a local web server such as the Live Server extension in VS Code or `python3 -m http.server`.
+
+## File Type Identifier Game
+
+The `fileTypeGame/` directory contains a mini-game called **File Type Identifier**. In this drag‑and‑drop game you match file extensions with categories such as "Document Files" or "Image Files." Open the game by launching `fileTypeGame/index.html` in your browser:
+
+```bash
+# From the repository root
+open fileTypeGame/index.html      # macOS
+xdg-open fileTypeGame/index.html  # Linux
+start fileTypeGame\index.html     # Windows
+```
+
+The game keeps track of correct and incorrect matches and shows your accuracy.
+
+Enjoy exploring the portfolio and the game!


### PR DESCRIPTION
## Summary
- document the portfolio site and File Type Identifier game
- provide instructions for opening `index.html` and the mini-game

## Testing
- `npm test` *(fails: `package.json` missing)*
- `pytest` *(fails: command not found)*