### PR TITLE
Add Jest testing setup for fileTypeGame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# EDLT Portfolio
+
+This project contains various educational materials and mini-games.
+
+## Running Tests
+
+Jest is used for testing. After installing dependencies run:
+
+```bash
+npm test
+```
+
+This will execute the test suite located under `fileTypeGame/__tests__`.

--- a/fileTypeGame/__tests__/game.test.js
+++ b/fileTypeGame/__tests__/game.test.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const {JSDOM} = require('jsdom');
+
+describe('file type game', () => {
+  let dom;
+  beforeAll(async () => {
+    const htmlPath = path.resolve(__dirname, '..', 'index.html');
+    dom = await JSDOM.fromFile(htmlPath, {
+      runScripts: 'dangerously',
+      resources: 'usable'
+    });
+    await new Promise(resolve => {
+      dom.window.addEventListener('load', resolve);
+    });
+  });
+
+  afterAll(() => {
+    dom.window.close();
+  });
+
+  test('newRound populates file layers with same extension', () => {
+    const {window} = dom;
+    // mock Math.random in this window
+    jest.spyOn(window.Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0);
+    window.newRound();
+    const layer1 = window.document.getElementById('file-layer-1').textContent;
+    const layer2 = window.document.getElementById('file-layer-2').textContent;
+    const layer3 = window.document.getElementById('file-layer-3').textContent;
+    expect(layer1).toBe(layer2);
+    expect(layer2).toBe(layer3);
+    expect(layer1).not.toBe('');
+    window.Math.random.mockRestore();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "edltportfolio",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^22.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize npm and add jest/jsdom dev dependencies
- document how to run tests in README
- create `game.test.js` using JSDOM

## Testing
- `npm test` *(fails: jest not found)*